### PR TITLE
Change fabric.mod.json to remove warn

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -2,7 +2,6 @@
   "schemaVersion": 1,
   "id": "loading-timer",
   "version": "${version}",
-
   "name": "Loading Timer",
   "description": "A simple tool that lets you know how much time it took for your client to load.",
   "authors": [
@@ -13,10 +12,8 @@
     "issues": "https://github.com/Blobanium/Loading-Timer/issues",
     "sources": "https://github.com/Blobanium/Loading-Timer"
   },
-
   "license": "MIT",
   "icon": "assets/lt/icon.png",
-
   "environment": "client",
   "entrypoints": {
     "main": [
@@ -46,10 +43,12 @@
   },
   "conflicts": {
     "ksyxis": ["1.0"]
-    },
+  },
+  "custom": {
     "modmenu":{
       "links":{
-        "Discord": "https://discord.gg/GkZtk5RkyG"
+        "modmenu.discord": "https://discord.gg/GkZtk5RkyG"
       }
     }
   }
+}


### PR DESCRIPTION
18:38:57.118
FabricLoader/Metadata
ForkJoinPool-1-worker-12
The mod "loading-timer" contains invalid entries in its mod json:
- Unsupported root entry "modmenu" at line 50 column 14
and change Discord to modmenu.discord to follow how modmenu work